### PR TITLE
make the demo page more prominent in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,12 @@
 A [CSS Logical Properties and Values](https://drafts.csswg.org/css-logical/) plugin for
 [Tailwind CSS](https://tailwindcss.com). Compatible with Tailwind v1.2.0+ and updated for Tailwind v2, with support for
 JIT Mode (including all [new features](https://tailwindcss.com/docs/just-in-time-mode#new-features) except arbitrary
-value support) and Dark Mode. View the [demo page](https://stevecochrane.github.io/tailwindcss-logical/) for a visual
-walkthrough, or read on to get started.
+value support) and Dark Mode.
+
+## Demo
+
+View the [demo page](https://stevecochrane.github.io/tailwindcss-logical/) for a visual walkthrough, or read on to get
+started.
 
 ## Usage
 


### PR DESCRIPTION
I never noticed there was a demo until I saw the release notes for v1.4.0 which were about the demo improvements.
I also suggest adding it as the repo website (About ⚙ > Website.)

Thanks for making this plugin! I really believe it is the way forward for proper RTL support in tailwindcss and with the introduction of JIT I hope tailwindlabs add all these utilities to core based on your plugin.