### PR TITLE
Remove Node 12 from build workflow, add 18 and 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Recent security vulnerabilities require updating Jest from 26 to 29, and 29 no longer supports Node 12 so Dependabot PRs are breaking. This removes Node 12 from the build workflow and adds 18 and 20. This only affects development builds of the plugin.